### PR TITLE
Add extension id to make storage API work on Firefox in dev.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,28 +1,31 @@
 {
-    "name": "Better",
-    "version": "0.0.1",
-    "icons": {
-      "48": "images/48.png",
-      "128": "images/128.png"
-    },
-    "description": "Find better products & services than the one you're currently visiting",
-    "permissions": ["activeTab", "storage"],
-    "background": {
-        "scripts": ["background.js"],
-        "persistent": false
-      },
-    "content_scripts": [
-        {
-            "matches": ["https://*/*", "http://*/*"],
-            "js": ["contentscript.js"]
-        }
-    ],
-    "manifest_version": 2,
-    "options_ui": {
-      "page": "options.html",
-      "open_in_tab": false
-    },
-    "web_accessible_resources": [
-      "defaultlist.json"
-    ]
-  }
+  "name": "Better",
+  "version": "0.0.1",
+  "icons": {
+    "48": "images/48.png",
+    "128": "images/128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{02d8a7bd-79ba-4808-8e11-f3e19af43f90}"
+    }
+  },
+  "description": "Find better products & services than the one you're currently visiting",
+  "permissions": ["activeTab", "storage"],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*/*", "http://*/*"],
+      "js": ["contentscript.js"]
+    }
+  ],
+  "manifest_version": 2,
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
+  "web_accessible_resources": ["defaultlist.json"]
+}


### PR DESCRIPTION
Adds a static GUID to run the extension in dev mode in Firefox. Firefox requires extensions to have a (non-temporary) id to access `storage.sync` APIs.
See - 
- https://bugzilla.mozilla.org/show_bug.cgi?id=1323228
- https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/

This change, however, makes Chromium-based browsers unhappy, as they do not recognize `browser_specific_settings`. The extension still works (tested in both chrome and brave), but shows errors in dev mode.

Closes #5 