### PR TITLE
Prevent popup elements from inherting styles of the host page

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -25,6 +25,37 @@ const altTemplate = "\
   <p style='margin: 0; font-size: 12px;'>${this.desc}</p> \
 </a>"
 
+const CONTAINER_STYLES = `
+    .better-ext-container * {
+        all: unset;
+    }
+
+    .better-ext-container h1,  .better-ext-container p, .better-ext-container div {
+        display:block;
+    }
+
+    .better-ext-container {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",  Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-size: 20px; 
+        line-height:1;
+        background-color: #ffcc49; 
+        position: fixed; 
+        bottom: 10px; 
+        right: 10px; 
+        width: 300px; 
+        box-shadow: 0px 10px 30px #222222; 
+        padding: 12px; 
+        text-align: center; 
+        z-index: 20000;
+    }
+`;
+
+function addPagePopupStyles() {
+  let styleTag = document.createElement("style");
+  styleTag.innerHTML = CONTAINER_STYLES;
+  document.head.append(styleTag);
+}
+
 function createNonRecommendedAlts(alternatives) {
     let nonRecommendedAlts = document.createElement("div");
     nonRecommendedAlts.setAttribute("style", "text-align: left;");
@@ -44,7 +75,10 @@ function createRecommendedAlt(recommendedAlternative) {
 
     let alternativeText = document.createElement("p");
     alternativeText.textContent = recommendedAlternative.desc;
-    alternativeText.setAttribute("style", "font-size: 20px; color: #222222; font-weight: bold; margin-top: 24px; line-height:1;");
+    alternativeText.setAttribute(
+      "style",
+      "font-size: 20px; color: #222222; font-weight: bold; margin: 20px 0; line-height:1;"
+    );
 
     let alternativeCTA = document.createElement("a");
     alternativeCTA.textContent = recommendedAlternative.name;
@@ -61,14 +95,10 @@ function createRecommendedAlt(recommendedAlternative) {
 
 function showBetter(match) {
     if(!match || !match.alternatives) return;
+    addPagePopupStyles();
     let alternatives = match.alternatives;
-
     let betterdiv = document.createElement("div");
-    betterdiv.setAttribute("style",
-                           "background-color: #ffcc49; position: fixed; bottom: 10px; right: 10px; width: 300px; \
-                            box-shadow: 0px 10px 30px #222222; padding: 12px; text-align: center; font-size: 20px; \
-                            z-index: 20000;")
-
+    betterdiv.classList.add("better-ext-container");
     betterdiv.appendChild(createRecommendedAlt(alternatives[0]));
 
     if(alternatives.length > 1) {


### PR DESCRIPTION
Use `all: unset` to prevent host styles from screwing up the styling of the Better popup.

## Screenshots - 
### Goodreads
<img width="423" alt="goodreads" src="https://user-images.githubusercontent.com/2878003/92993498-ad5ba380-f50f-11ea-8c30-3fdedc67e712.png">

### Slack
<img width="878" alt="slack" src="https://user-images.githubusercontent.com/2878003/92993502-b64c7500-f50f-11ea-80df-f77c3407387c.png">

### Google Chrome
<img width="1111" alt="chrome" src="https://user-images.githubusercontent.com/2878003/92993506-bd738300-f50f-11ea-9fc9-d280eca47057.png">


Closing #16